### PR TITLE
chore: remove include-markdown plugin from mkdocs.yml

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -25,7 +25,6 @@ theme:
 
 # Plugins
 plugins:
-  - include-markdown
   - blog:
       authors_file: "{blog}/.authors.yml"
 


### PR DESCRIPTION
Removed the 'include-markdown' plugin from the configuration.